### PR TITLE
運営管理者を追加、全ユーザーの取引確認ページ追加

### DIFF
--- a/app/controllers/administrator/investments_controller.rb
+++ b/app/controllers/administrator/investments_controller.rb
@@ -1,0 +1,14 @@
+class Administrator::InvestmentsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_administrator
+
+  def index
+    @investments = Investment.includes(:user, :project).order(created_at: :desc)
+  end
+
+  private
+
+  def check_administrator
+    redirect_to root_path unless current_user.administrator?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_projects, through: :likes, source: :project
 
-  enum role: { user: 0, administrator: 1 }
+  enum role: { default: 0, administrator: 1 }
 
   def owner?(project)
     self == project.owner

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_projects, through: :likes, source: :project
 
+  enum role: { user: 0, administrator: 1 }
+
   def owner?(project)
     self == project.owner
   end

--- a/app/views/administrator/investments/index.html.slim
+++ b/app/views/administrator/investments/index.html.slim
@@ -1,0 +1,16 @@
+h1 全ユーザーの投資一覧
+
+table
+  thead
+    tr
+      th = User.human_attribute_name(:email)
+      th = Project.human_attribute_name(:name)
+      th = Investment.human_attribute_name(:price)
+      th = Investment.human_attribute_name(:created_at)
+  tbody
+    - @investments.each do |investment|
+      tr
+        td = investment.user.email
+        td = investment.project.name
+        td = investment.price.to_s(:currency)
+        td = l investment.created_at, format: :long

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,3 +3,5 @@ ul
     li = link_to 'ログアウト', destroy_user_session_path, method: :delete
     li = link_to 'マイプロジェクト', admin_projects_path
     li = link_to '全てのプロジェクト', projects_path
+    - if current_user.administrator?
+      li = link_to '運営管理者画面', administrator_root_path

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -6,7 +6,7 @@ ja:
     attributes:
       project:
         id: ID
-        name: 名前
+        name: プロジェクト名
         description: 説明
         price: 目標金額
         investments_amount: 投資金額合計

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :projects
   end
 
-  # 運営管理車画面
+  # 運営管理者画面
   namespace :administrator do
     root 'investments#index'
     resources :investments, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  namespace :administer do
-    get 'investments/index'
-  end
   devise_for :users
 
   root 'projects#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :administer do
+    get 'investments/index'
+  end
   devise_for :users
 
   root 'projects#index'
@@ -11,5 +14,11 @@ Rails.application.routes.draw do
   namespace :admin do
     root 'projects#index'
     resources :projects
+  end
+
+  # 運営管理車画面
+  namespace :administrator do
+    root 'investments#index'
+    resources :investments, only: %i[index]
   end
 end

--- a/db/migrate/20190422090801_add_role_to_user.rb
+++ b/db/migrate/20190422090801_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, default: 0, null: false, limit: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_18_092134) do
+ActiveRecord::Schema.define(version: 2019_04_22_090801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_092134) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", limit: 2, default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#10 
運営管理者を追加し、全ユーザの取引確認ページを追加しました。確認をお願いいたします。
- userモデルにroleカラムを追加
- 画面ヘッダに運営管理者ページへのリンク追加
- 運営管理者向けに全ユーザーの取引一覧ページを追加
（administrator::investmentsコントローラの#index追加、対応する画面を追加）